### PR TITLE
feat(action): Make sure cURL are installed in actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Download cURL
+      run: |
+        apt-get update
+        apt-get install curl
     - name: Download Detekt Configuration
       run: |
         echo 'Downloading configuration'


### PR DESCRIPTION
cURL is not provided default in self-hosted runners, so we need to install it in the detekt action.