### PR TITLE
chore(deps): bump detekt to 1.23.8 and add curl --fail flag [NOJIRA]

### DIFF
--- a/Dockerfile.monta-detekt
+++ b/Dockerfile.monta-detekt
@@ -1,11 +1,11 @@
 FROM openjdk:21
 
-ARG DETEKT_VERSION=1.23.7
+ARG DETEKT_VERSION=1.23.8
 
 WORKDIR /detekt
 
-RUN curl -L -o detekt.jar https://github.com/detekt/detekt/releases/download/v${DETEKT_VERSION}/detekt-cli-${DETEKT_VERSION}-all.jar
-RUN curl -L -o detekt-formatting.jar https://github.com/detekt/detekt/releases/download/v${DETEKT_VERSION}/detekt-formatting-${DETEKT_VERSION}.jar
+RUN curl -fL -o detekt.jar https://github.com/detekt/detekt/releases/download/v${DETEKT_VERSION}/detekt-cli-${DETEKT_VERSION}-all.jar
+RUN curl -fL -o detekt-formatting.jar https://github.com/detekt/detekt/releases/download/v${DETEKT_VERSION}/detekt-formatting-${DETEKT_VERSION}.jar
 
 COPY conf/detekt.yml detekt.yml
 COPY .docker/run_monta_detekt.sh /bin/run_monta_detekt


### PR DESCRIPTION
## Summary
- Bumps Detekt from 1.23.7 to 1.23.8 — release notes: https://github.com/detekt/detekt/releases/tag/v1.23.8
- Adds `-f` (`--fail`) flag to both `curl` invocations so the Docker build fails immediately on HTTP errors (4xx/5xx) instead of silently writing an error page as the JAR file

## Future bump to version 2?

When Detekt releases a version compatible with JDK 25 (version 2) https://github.com/detekt/detekt/releases - we should upgrade to that - also uses a newer ktlint

## Test plan
- [ ] Verify Docker image builds successfully with the new Detekt version

🤖 Generated with [Claude Code](https://claude.com/claude-code)