### PR TITLE
refactor: drop Nandi/Detekt-Action dependency, run detekt + reviewdog in-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can optionally provide your own detekt.yml configuration file instead of usi
 
 | Parameter | Description | Required | Default |
 |-----------|-------------|----------|---------|
-| `github-token` | GitHub token used for generating releases | Yes | - |
+| `github-token` | GitHub token used by reviewdog to post annotations on the pull request | Yes | - |
 | `detekt-config-file` | Path to custom detekt.yml config file | No | Uses centralized config |
 
 #### Local Usage

--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,14 @@ runs:
         java-version: "21"
     - name: Setup Detekt configuration
       run: |
-        if [ -n "${{ inputs.detekt-config-file }}" ]; then
-          echo "Using provided custom detekt configuration file"
-          cp "${{ inputs.detekt-config-file }}" detekt.yml
+        config_file="${{ inputs.detekt-config-file }}"
+        if [ -n "$config_file" ]; then
+          echo "Using provided custom detekt configuration file: $config_file"
+          # A repo whose config is already named detekt.yml needs no copy
+          # (cp would fail on identical source and destination).
+          if [ "$config_file" != "detekt.yml" ]; then
+            cp "$config_file" detekt.yml
+          fi
         else
           echo "Using bundled centralized configuration"
           cp "${{ github.action_path }}/conf/detekt.yml" detekt.yml

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: "Detekt Action"
-description: "Run Detekt from a centralized location"
+description: "Run Detekt with reviewdog from a centralized location"
 inputs:
   github-token:
-    description: "Github token used for generating releases"
+    description: "GitHub token used by reviewdog to post annotations on the pull request"
     required: true
   detekt-config-file:
     description: "Path to custom detekt.yml config file (optional)"
@@ -10,27 +10,50 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Download cURL & update Git
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y curl
-        sudo apt-get install -y git
-      shell: bash
     - name: Checkout
       uses: actions/checkout@v6
-    - name: Setup Detekt Configuration
+    - name: Set up JDK
+      uses: actions/setup-java@v5
+      with:
+        distribution: "corretto"
+        java-version: "21"
+    - name: Setup Detekt configuration
       run: |
         if [ -n "${{ inputs.detekt-config-file }}" ]; then
-          echo 'Using provided custom detekt configuration file'
+          echo "Using provided custom detekt configuration file"
           cp "${{ inputs.detekt-config-file }}" detekt.yml
         else
-          echo 'Using bundled centralized configuration'
+          echo "Using bundled centralized configuration"
           cp "${{ github.action_path }}/conf/detekt.yml" detekt.yml
         fi
-        ls -a
       shell: bash
-    - name: Run Detekt
-      uses: Nandi/Detekt-Action@1.23.8
-      with:
-        github_token: ${{ inputs.github-token }}
-        detekt_config: detekt.yml
+    - name: Run Detekt with reviewdog
+      run: |
+        set -o pipefail
+        tools_dir="${{ github.action_path }}/.tools"
+        mkdir -p "$tools_dir"
+        echo "::group::Download detekt ${DETEKT_VERSION} & reviewdog ${REVIEWDOG_VERSION}"
+        curl -fsSL -o "$tools_dir/detekt.jar" \
+          "https://github.com/detekt/detekt/releases/download/v${DETEKT_VERSION}/detekt-cli-${DETEKT_VERSION}-all.jar"
+        curl -fsSL -o "$tools_dir/detekt-formatting.jar" \
+          "https://github.com/detekt/detekt/releases/download/v${DETEKT_VERSION}/detekt-formatting-${DETEKT_VERSION}.jar"
+        curl -fsSL "https://raw.githubusercontent.com/reviewdog/reviewdog/v${REVIEWDOG_VERSION}/install.sh" \
+          | sh -s -- -b "$tools_dir" "v${REVIEWDOG_VERSION}"
+        echo "::endgroup::"
+        # reviewdog (filter-mode=added) shells out to git inside the workspace
+        git config --global --add safe.directory "$GITHUB_WORKSPACE" || true
+        # detekt exits non-zero when issues are found; the pull-request status is owned
+        # by reviewdog's github-pr-check run, so don't let detekt's exit abort the step.
+        java -jar "$tools_dir/detekt.jar" \
+          --config detekt.yml \
+          --report xml:detekt_report.xml \
+          --excludes "**/build/**,**/.idea/**" \
+          --plugins "$tools_dir/detekt-formatting.jar" || true
+        "$tools_dir/reviewdog" -f=checkstyle -name="detekt" \
+          -reporter="github-pr-check" -level="error" -filter-mode="added" \
+          < detekt_report.xml
+      shell: bash
+      env:
+        DETEKT_VERSION: "1.23.8"
+        REVIEWDOG_VERSION: "0.17.4"
+        REVIEWDOG_GITHUB_API_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
## Summary

`monta-app/detekt-action` was a thin composite wrapper that still delegated to the third-party fork `Nandi/Detekt-Action@1.23.8` ([action.yml#L33](https://github.com/monta-app/detekt-action/blob/main/action.yml#L33)). Every repo that "migrated" to our action was therefore still pulling in Nandi's fork transitively — the migration off third-party detekt actions was never actually complete.

This PR makes the action self-contained: it runs detekt + reviewdog itself and drops the `Nandi/Detekt-Action` dependency entirely.

## Changes

- Replace the `uses: Nandi/Detekt-Action@1.23.8` step with composite steps that:
  1. Download detekt `1.23.8` (+ `detekt-formatting`) and reviewdog `0.17.4`
  2. Run detekt → checkstyle XML report
  3. Pipe the report to reviewdog (`reporter=github-pr-check`, `level=error`, `filter-mode=added`)
- Add an explicit `setup-java` (Corretto 21) step so the action no longer depends on a JRE-bundled Docker image and runs on any runner (incl. self-hosted arm64) without Docker.
- Standardise on detekt **1.23.8** — the same version already pinned in `conf/detekt.yml` and `Dockerfile.monta-detekt`. (Nandi's image ran `2.0.0-alpha.0` against our 1.23 config, a latent inconsistency.)

## Behaviour

The public interface is unchanged (`github-token`, optional `detekt-config-file`), so the repos already consuming `monta-app/detekt-action@main` need **no changes**. reviewdog still posts findings as a `detekt` `github-pr-check` run with the same level/filter defaults Nandi used, so branch-protection rules relying on that check keep working.

## Verification

- `action.yml` validated as YAML.
- All three download URLs (detekt-cli, detekt-formatting, reviewdog install.sh) return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)